### PR TITLE
feat(runs): add empty Livewire page at /runs + fix layout usage

### DIFF
--- a/app/app/Livewire/RunsTable.php
+++ b/app/app/Livewire/RunsTable.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Livewire;
+
+use Livewire\Component;
+
+class RunsTable extends Component
+{
+    public function render()
+    {
+        return view('livewire.runs-table');
+    }
+}

--- a/app/resources/views/livewire/runs-table.blade.php
+++ b/app/resources/views/livewire/runs-table.blade.php
@@ -1,0 +1,9 @@
+<div class="max-w-5xl mx-auto p-6">
+    <h1 class="text-2xl font-semibold mb-4">Runs</h1>
+
+    <div class="rounded-2xl shadow p-6">
+        <p class="text-sm opacity-70">
+            Здесь будет таблица пробежек и фильтры. Пока — заглушка.
+        </p>
+    </div>
+</div>

--- a/app/resources/views/runs/index.blade.php
+++ b/app/resources/views/runs/index.blade.php
@@ -1,0 +1,6 @@
+{{-- resources/views/runs/index.blade.php --}}
+<x-app-layout>
+    <div class="py-6">
+        <livewire:runs-table />
+    </div>
+</x-app-layout>

--- a/app/routes/web.php
+++ b/app/routes/web.php
@@ -15,6 +15,9 @@ Route::middleware('auth')->group(function () {
     Route::get('/profile', [ProfileController::class, 'edit'])->name('profile.edit');
     Route::patch('/profile', [ProfileController::class, 'update'])->name('profile.update');
     Route::delete('/profile', [ProfileController::class, 'destroy'])->name('profile.destroy');
+    Route::get('/runs', function() {
+        return view('runs.index');
+    })->name('runs.index');
 });
 
 require __DIR__.'/auth.php';

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,6 @@ services:
       - ./app:/var/www/html
       - ./app/.composer:/var/www/.composer
       - ./app/.npm:/var/www/.npm
-    env_file: .env
     depends_on:
       - db
       - redis


### PR DESCRIPTION
## Что сделано
- Livewire-компонент `RunsTable` и страница `/runs`
- Обёртка через `<x-app-layout>` (фикc ошибки `$slot`)
- Базовая разметка под будущие фильтры/таблицу

## Как проверить
1) Зарегистрироваться/залогиниться
2) Открыть /runs — видна заглушка и компонент подключается без ошибок

## Миграции/Очереди
- Нет

## Скриншоты
<img width="1088" height="722" alt="Screenshot 2025-09-20 at 21 53 18" src="https://github.com/user-attachments/assets/1521d846-b5f2-4b65-89b0-30f6f5f0ef7b" />
