### PR TITLE
build/devops: prod Dockerfile stages + deploy workflow

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -1,4 +1,6 @@
-# base
+# ========================
+# Base (PHP-FPM + Composer)
+# ========================
 FROM php:8.3-fpm-alpine AS base
 RUN apk add --no-cache git zip unzip curl bash icu-dev oniguruma-dev libzip-dev libpng-dev \
  && docker-php-ext-install pdo pdo_mysql intl zip \
@@ -6,7 +8,47 @@ RUN apk add --no-cache git zip unzip curl bash icu-dev oniguruma-dev libzip-dev 
 COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
 WORKDIR /var/www/html
 
-# dev image (with Node for asset build)
+# ========================
+# Dev image (with Node)
+# ========================
 FROM base AS dev
 RUN apk add --no-cache nodejs npm
+CMD ["php-fpm"]
+
+# ========================
+# Assets build (Node only)
+# ========================
+FROM node:20-alpine AS assets
+WORKDIR /app
+# кешируем зависимости
+COPY app/package*.json ./
+RUN npm ci
+# копируем код для сборки фронта
+COPY app ./
+RUN npm run build
+# результат: /app/public/build
+
+# ========================
+# Production image
+# ========================
+FROM base AS prod
+WORKDIR /var/www/html
+
+# 1) Composer deps (кеш слоёв)
+COPY app/composer.json app/composer.lock ./
+RUN composer install --no-dev --no-interaction --prefer-dist --optimize-autoloader
+
+# 2) Код приложения
+COPY app ./
+
+# 3) Готовые фронт-ассеты из assets-стейджа
+COPY --from=assets /app/public/build ./public/build
+
+# 4) Оптимизации Laravel
+RUN php artisan config:cache \
+ && php artisan route:cache \
+ && php artisan view:cache \
+ && chown -R www-data:www-data storage bootstrap/cache \
+ && chmod -R ug+rw storage bootstrap/cache
+
 CMD ["php-fpm"]

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,59 @@
+name: Deploy
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Login GHCR
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+
+      - name: Build prod image
+        run: |
+          docker build -f .docker/Dockerfile --target prod \
+            -t ghcr.io/${{ github.repository }}:${{ github.sha }} \
+            -t ghcr.io/${{ github.repository }}:latest \
+            .
+
+      - name: Push image
+        run: |
+          docker push ghcr.io/${{ github.repository }}:${{ github.sha }}
+          docker push ghcr.io/${{ github.repository }}:latest
+
+      # (опц.) выложим текущий код в /var/lib/42k/code, чтобы nginx видел public/ и статику из образа:
+      - name: Pack built code for nginx (public)
+        run: |
+          mkdir -p out && rsync -a app/ out/
+          tar -C out -czf code.tgz .
+      - name: Upload code to server
+        uses: appleboy/scp-action@v0.1.7
+        with:
+          host: ${{ secrets.SSH_HOST }}
+          username: ${{ secrets.SSH_USER }}
+          key: ${{ secrets.SSH_KEY }}
+          source: "code.tgz"
+          target: "/var/lib/42k/"
+
+      - name: Deploy on server
+        uses: appleboy/ssh-action@v1.2.0
+        with:
+          host: ${{ secrets.SSH_HOST }}
+          username: ${{ secrets.SSH_USER }}
+          key: ${{ secrets.SSH_KEY }}
+          script: |
+            set -e
+            mkdir -p /var/lib/42k/code
+            tar -C /var/lib/42k/code -xzf /var/lib/42k/code.tgz
+            cd /opt/42k
+            export APP_TAG=latest
+            docker login ghcr.io -u ${{ github.actor }} -p ${{ secrets.GITHUB_TOKEN }}
+            docker compose -f docker-compose.prod.yml pull
+            docker compose -f docker-compose.prod.yml up -d --remove-orphans
+

--- a/app/app/Livewire/RunsTable.php
+++ b/app/app/Livewire/RunsTable.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Livewire;
+
+use Livewire\Component;
+
+class RunsTable extends Component
+{
+    public function render()
+    {
+        return view('livewire.runs-table');
+    }
+}

--- a/app/resources/views/livewire/runs-table.blade.php
+++ b/app/resources/views/livewire/runs-table.blade.php
@@ -1,0 +1,9 @@
+<div class="max-w-5xl mx-auto p-6">
+    <h1 class="text-2xl font-semibold mb-4">Runs</h1>
+
+    <div class="rounded-2xl shadow p-6">
+        <p class="text-sm opacity-70">
+            Здесь будет таблица пробежек и фильтры. Пока — заглушка.
+        </p>
+    </div>
+</div>

--- a/app/resources/views/runs/index.blade.php
+++ b/app/resources/views/runs/index.blade.php
@@ -1,0 +1,6 @@
+{{-- resources/views/runs/index.blade.php --}}
+<x-app-layout>
+    <div class="py-6">
+        <livewire:runs-table />
+    </div>
+</x-app-layout>

--- a/app/routes/web.php
+++ b/app/routes/web.php
@@ -15,6 +15,9 @@ Route::middleware('auth')->group(function () {
     Route::get('/profile', [ProfileController::class, 'edit'])->name('profile.edit');
     Route::patch('/profile', [ProfileController::class, 'update'])->name('profile.update');
     Route::delete('/profile', [ProfileController::class, 'destroy'])->name('profile.destroy');
+    Route::get('/runs', function() {
+        return view('runs.index');
+    })->name('runs.index');
 });
 
 require __DIR__.'/auth.php';

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,6 @@ services:
       - ./app:/var/www/html
       - ./app/.composer:/var/www/.composer
       - ./app/.npm:/var/www/.npm
-    env_file: .env
     depends_on:
       - db
       - redis


### PR DESCRIPTION
## Что сделано
- **Docker**: добавлены стейджи `assets` и `prod` в `.docker/Dockerfile` (сборка Vite-ассетов, оптимизация Laravel: `config/route/view:cache`).
- **CI/CD**: новый workflow `deploy.yml` — собирает prod-образ, пушит в GHCR и деплоит на сервер по SSH.
- **Runs**: Livewire-компонент `RunsTable` и страница `/runs` с обёрткой `<x-app-layout>`; маршрут под `auth`.

## Как проверить
CI:

- Убедиться, что workflow **CI** зелёный (сборка, vite build, тесты).
- В этом PR появится новый workflow **Deploy** (запускается на push в `main`).

Prod (после мержа в `main`, если настроен сервер и secrets):

- Проверить, что деплой-джоб прошёл: образ в GHCR обновился, контейнеры на сервере поднялись.

## Миграции/Очереди
Миграций нет.
Очереди не затрагивались.

## Скриншоты
Нет