### PR TITLE
feat(users): implement DDD architecture with ULID support

### DIFF
--- a/app/app/Http/Controllers/Auth/NewPasswordController.php
+++ b/app/app/Http/Controllers/Auth/NewPasswordController.php
@@ -3,7 +3,7 @@
 namespace App\Http\Controllers\Auth;
 
 use App\Http\Controllers\Controller;
-use App\Models\User;
+use App\Users\Infrastructure\Database\Eloquent\Models\UserModel;
 use Illuminate\Auth\Events\PasswordReset;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
@@ -38,10 +38,10 @@ class NewPasswordController extends Controller
 
         // Here we will attempt to reset the user's password. If it is successful we
         // will update the password on an actual user model and persist it to the
-        // database. Otherwise we will parse the error and return the response.
+        // database. Otherwise, we will parse the error and return the response.
         $status = Password::reset(
             $request->only('email', 'password', 'password_confirmation', 'token'),
-            function (User $user) use ($request) {
+            function (UserModel $user) use ($request) {
                 $user->forceFill([
                     'password' => Hash::make($request->password),
                     'remember_token' => Str::random(60),

--- a/app/app/Http/Controllers/Auth/RegisteredUserController.php
+++ b/app/app/Http/Controllers/Auth/RegisteredUserController.php
@@ -3,17 +3,24 @@
 namespace App\Http\Controllers\Auth;
 
 use App\Http\Controllers\Controller;
-use App\Models\User;
+use App\Users\Domain\Contracts\UserRepository;
+use App\Users\Domain\Entity\User;
+use App\Users\Infrastructure\Database\Eloquent\Models\UserModel;
 use Illuminate\Auth\Events\Registered;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Validation\Rules;
+use Illuminate\Validation\ValidationException;
 use Illuminate\View\View;
 
 class RegisteredUserController extends Controller
 {
+    public function __construct(private readonly UserRepository $userRepository)
+    {
+    }
+
     /**
      * Display the registration view.
      */
@@ -25,25 +32,28 @@ class RegisteredUserController extends Controller
     /**
      * Handle an incoming registration request.
      *
-     * @throws \Illuminate\Validation\ValidationException
+     * @throws ValidationException
      */
     public function store(Request $request): RedirectResponse
     {
         $request->validate([
             'name' => ['required', 'string', 'max:255'],
-            'email' => ['required', 'string', 'lowercase', 'email', 'max:255', 'unique:'.User::class],
+            'email' => ['required', 'string', 'lowercase', 'email', 'max:255', 'unique:users'],
             'password' => ['required', 'confirmed', Rules\Password::defaults()],
         ]);
 
-        $user = User::create([
-            'name' => $request->name,
-            'email' => $request->email,
-            'password' => Hash::make($request->password),
-        ]);
+        $userEntity = new User(
+            $request->name,
+            $request->email,
+            Hash::make($request->password),
+        );
 
-        event(new Registered($user));
+        $user = $this->userRepository->store($userEntity);
+        $userModel = UserModel::query()->find($user->ulid);
 
-        Auth::login($user);
+        event(new Registered($userModel));
+
+        Auth::login($userModel);
 
         return redirect(route('dashboard', absolute: false));
     }

--- a/app/app/Http/Requests/ProfileUpdateRequest.php
+++ b/app/app/Http/Requests/ProfileUpdateRequest.php
@@ -2,7 +2,7 @@
 
 namespace App\Http\Requests;
 
-use App\Models\User;
+use App\Users\Infrastructure\Database\Eloquent\Models\UserModel;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
 
@@ -23,7 +23,7 @@ class ProfileUpdateRequest extends FormRequest
                 'lowercase',
                 'email',
                 'max:255',
-                Rule::unique(User::class)->ignore($this->user()->id),
+                Rule::unique(UserModel::class)->ignore($this->user()->id),
             ],
         ];
     }

--- a/app/app/Runs/Infrastructure/Database/Eloquent/Models/RunModel.php
+++ b/app/app/Runs/Infrastructure/Database/Eloquent/Models/RunModel.php
@@ -4,10 +4,16 @@ declare(strict_types=1);
 
 namespace App\Runs\Infrastructure\Database\Eloquent\Models;
 
+use Carbon\CarbonInterface;
+use Database\Factories\RunFactory;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
 final class RunModel extends Model
 {
+    use HasFactory;
+
     protected $table = 'runs';
 
     protected $fillable = [
@@ -31,4 +37,27 @@ final class RunModel extends Model
         'rpe' => 'integer',
         'shoe_id' => 'integer',
     ];
+
+    protected static function newFactory(): RunFactory
+    {
+        return RunFactory::new();
+    }
+
+    /** Показывать пробежки конкретного пользователя */
+    public function scopeForUser(Builder $q, int $userId): Builder
+    {
+        return $q->where('user_id', $userId);
+    }
+
+    /** Ограничить по диапазону времени (включительно) */
+    public function scopeBetween(Builder $q, CarbonInterface $from, CarbonInterface $to): Builder
+    {
+        return $q->whereBetween('run_at', [$from, $to]);
+    }
+
+    /** Сортировка по дате забега — новые сначала */
+    public function scopeRecent(Builder $q): Builder
+    {
+        return $q->orderByDesc('run_at');
+    }
 }

--- a/app/app/Users/Domain/Contracts/UserRepository.php
+++ b/app/app/Users/Domain/Contracts/UserRepository.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Users\Domain\Contracts;
+
+use App\Users\Domain\Entity\User;
+
+interface UserRepository
+{
+    /**
+     * Найти пользователя по ID
+     */
+    public function find(?string $ulid): ?User;
+
+    /**
+     * Найти пользователя по email
+     */
+    public function findByEmail(string $email): ?User;
+
+    /**
+     * Сохранить пользователя (создать или обновить)
+     */
+    public function store(User $user): User;
+
+    /**
+     * Удалить пользователя по ID
+     */
+    public function delete(string $ulid): void;
+
+    /**
+     * Проверить существование пользователя с указанным email
+     */
+    public function existsByEmail(string $email): bool;
+}

--- a/app/app/Users/Domain/Entity/User.php
+++ b/app/app/Users/Domain/Entity/User.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Users\Domain\Entity;
+
+final readonly class User
+{
+    public function __construct(
+        public string              $name,
+        public string              $email,
+        public string              $password,
+        public ?string             $ulid = null,
+        public ?\DateTimeImmutable $emailVerifiedAt = null,
+        public ?string             $rememberToken = null,
+        public ?\DateTimeImmutable $createdAt = null,
+        public ?\DateTimeImmutable $updatedAt  = null,
+    ) {
+    }
+
+    /**
+     * Проверяет, подтвержден ли email пользователя
+     */
+    public function isEmailVerified(): bool
+    {
+        return $this->emailVerifiedAt !== null;
+    }
+
+    /**
+     * Возвращает инициалы пользователя
+     */
+    public function getInitials(): string
+    {
+        $words = explode(' ', trim($this->name));
+        $initials = '';
+
+        foreach ($words as $word) {
+            if ($word !== '') {
+                $initials .= mb_strtoupper(mb_substr($word, 0, 1));
+            }
+        }
+
+        return $initials !== '' ? $initials : 'U';
+    }
+}

--- a/app/app/Users/Infrastructure/Database/Eloquent/Models/UserModel.php
+++ b/app/app/Users/Infrastructure/Database/Eloquent/Models/UserModel.php
@@ -1,16 +1,22 @@
 <?php
 
-namespace App\Models;
+declare(strict_types=1);
 
-// use Illuminate\Contracts\Auth\MustVerifyEmail;
+namespace App\Users\Infrastructure\Database\Eloquent\Models;
+
+use Database\Factories\UserFactory;
+use Illuminate\Database\Eloquent\Concerns\HasUlids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 
-class User extends Authenticatable
+final class UserModel extends Authenticatable
 {
-    /** @use HasFactory<\Database\Factories\UserFactory> */
-    use HasFactory, Notifiable;
+    use HasFactory;
+    use HasUlids;
+    use Notifiable;
+
+    protected $table = 'users';
 
     /**
      * The attributes that are mass assignable.
@@ -44,5 +50,10 @@ class User extends Authenticatable
             'email_verified_at' => 'datetime',
             'password' => 'hashed',
         ];
+    }
+
+    protected static function newFactory(): UserFactory
+    {
+        return UserFactory::new();
     }
 }

--- a/app/app/Users/Infrastructure/Database/Eloquent/Repositories/EloquentUserRepository.php
+++ b/app/app/Users/Infrastructure/Database/Eloquent/Repositories/EloquentUserRepository.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Users\Infrastructure\Database\Eloquent\Repositories;
+
+use App\Shared\Infrastructure\Casting\Caster;
+use App\Shared\Infrastructure\Casting\CastType;
+use App\Users\Domain\Contracts\UserRepository;
+use App\Users\Domain\Entity\User;
+use App\Users\Infrastructure\Database\Eloquent\Models\UserModel;
+use RuntimeException;
+
+class EloquentUserRepository implements UserRepository
+{
+    /**
+     * @inheritDoc
+     * @throws \Exception
+     */
+    public function find(?string $ulid): ?User
+    {
+        if (null === $ulid) {
+            return null;
+        }
+
+        $model = UserModel::query()->find($ulid);
+        if (null === $model) {
+            return null;
+        }
+        if (!$model instanceof UserModel) {
+            throw new RuntimeException('Unexpected model type in EloquentUserRepository::find');
+        }
+
+        return $this->mapToEntity($model);
+    }
+
+    /**
+     * @inheritDoc
+     * @throws \Exception
+     */
+    public function findByEmail(string $email): ?User
+    {
+        $model = UserModel::query()->where('email', $email)->first();
+        if (null === $model) {
+            return null;
+        }
+        if (!$model instanceof UserModel) {
+            throw new RuntimeException('Unexpected model type in EloquentUserRepository::findByEmail');
+        }
+
+        return $this->mapToEntity($model);
+    }
+
+    /**
+     * @inheritDoc
+     * @throws \Exception
+     */
+    public function store(User $user): User
+    {
+        if ($user->ulid !== null) {
+            $model = UserModel::query()->find($user->ulid);
+            if ($model === null) {
+                throw new RuntimeException("User with id={$user->ulid} not found for update");
+            }
+        } else {
+            $model = new UserModel();
+        }
+
+        if (!$model instanceof UserModel) {
+            throw new RuntimeException('Unexpected model type in EloquentUserRepository::store');
+        }
+
+        $model->setAttribute('name', $user->name);
+        $model->setAttribute('email', $user->email);
+        $model->setAttribute('password', $user->password);
+        $model->setAttribute('email_verified_at', $user->emailVerifiedAt);
+        $model->setAttribute('remember_token', $user->rememberToken);
+
+        $model->save();
+
+        return $this->mapToEntity($model);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function delete(string $ulid): void
+    {
+        UserModel::query()->whereKey($ulid)->delete();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function existsByEmail(string $email): bool
+    {
+        return UserModel::query()->where('email', $email)->exists();
+    }
+
+    /**
+     * @throws \Exception
+     */
+    private function mapToEntity(UserModel $model): User
+    {
+        return new User(
+            (string) $model->getAttribute('name'),
+            (string) $model->getAttribute('email'),
+            (string) $model->getAttribute('password'),
+            (string) $model->getKey(),
+            Caster::cast($model->getAttribute('email_verified_at'), CastType::DateTimeImmutableNullable),
+            $model->getAttribute('remember_token'),
+            Caster::cast($model->getAttribute('created_at'), CastType::DateTimeImmutableNullable),
+            Caster::cast($model->getAttribute('updated_at'), CastType::DateTimeImmutableNullable)
+        );
+    }
+}

--- a/app/app/Users/UsersServiceProvider.php
+++ b/app/app/Users/UsersServiceProvider.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Users;
+
+use App\Users\Domain\Contracts\UserRepository;
+use App\Users\Infrastructure\Database\Eloquent\Repositories\EloquentUserRepository;
+use Illuminate\Support\ServiceProvider;
+
+class UsersServiceProvider extends ServiceProvider
+{
+    /**
+     * Register services.
+     */
+    public function register(): void
+    {
+        $this->app->bind(UserRepository::class, EloquentUserRepository::class);
+    }
+
+    /**
+     * Bootstrap services.
+     */
+    public function boot(): void
+    {
+    }
+}

--- a/app/bootstrap/providers.php
+++ b/app/bootstrap/providers.php
@@ -3,4 +3,5 @@
 return [
     App\Providers\AppServiceProvider::class,
     App\Runs\RunsServiceProvider::class,
+    App\Users\UsersServiceProvider::class,
 ];

--- a/app/config/auth.php
+++ b/app/config/auth.php
@@ -62,7 +62,7 @@ return [
     'providers' => [
         'users' => [
             'driver' => 'eloquent',
-            'model' => env('AUTH_MODEL', App\Models\User::class),
+            'model' => env('AUTH_MODEL', App\Users\Infrastructure\Database\Eloquent\Models\UserModel::class),
         ],
 
         // 'users' => [

--- a/app/database/factories/RunFactory.php
+++ b/app/database/factories/RunFactory.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Factories;
+
+use App\Runs\Infrastructure\Database\Eloquent\Models\RunModel;
+use Carbon\Carbon;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class RunFactory extends Factory
+{
+    protected $model = RunModel::class;
+
+    /**
+     * @inheritDoc
+     */
+    public function definition(): array
+    {
+        $distance = $this->faker->numberBetween(6000, 12000); // 6-12 км
+        $pace = $this->faker->numberBetween(300, 390); // 5:00-6:30 мин/км
+        $duration = (int) round(($distance / 1000) * $pace);
+
+        $runAt = Carbon::now('UTC')
+            ->subDays($this->faker->numberBetween(0, 60))
+            ->subHours($this->faker->numberBetween(0, 23))
+            ->subMinutes($this->faker->numberBetween(0, 59));
+
+        return [
+            'user_id' => 1,
+            'run_at' => $runAt,
+            'distance' => $distance,
+            'duration' => $duration,
+            'avg_hr' => $this->faker->optional(0.7)->numberBetween(120, 175),
+            'cadence' => $this->faker->optional(0.7)->numberBetween(150, 190),
+            'rpe' => $this->faker->optional(0.7)->numberBetween(3, 8),
+            'shoe_id' => $this->faker->optional(0.4)->numberBetween(1, 5),
+            'notes' => $this->faker->optional(0.3)->sentence(),
+        ];
+    }
+}

--- a/app/database/factories/UserFactory.php
+++ b/app/database/factories/UserFactory.php
@@ -2,15 +2,18 @@
 
 namespace Database\Factories;
 
+use App\Users\Infrastructure\Database\Eloquent\Models\UserModel;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Str;
 
 /**
- * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\User>
+ * @extends Factory<UserModel>
  */
 class UserFactory extends Factory
 {
+    protected $model = UserModel::class;
+
     /**
      * The current password being used by the factory.
      */

--- a/app/database/migrations/2025_09_26_175625_update_users_table_to_ulid.php
+++ b/app/database/migrations/2025_09_26_175625_update_users_table_to_ulid.php
@@ -1,0 +1,60 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        // 1. Создаем новую таблицу с ULID
+        Schema::create('users_new', function (Blueprint $table) {
+            $table->ulid('id')->primary();
+            $table->string('name');
+            $table->string('email')->unique();
+            $table->timestamp('email_verified_at')->nullable();
+            $table->string('password');
+            $table->rememberToken();
+            $table->timestamps();
+        });
+
+        // 2. Копируем данные из старой таблицы в новую
+        $users = \DB::table('users')->get();
+        foreach ($users as $user) {
+            \DB::table('users_new')->insert([
+                'id' => \Illuminate\Support\Str::ulid(),
+                'name' => $user->name,
+                'email' => $user->email,
+                'email_verified_at' => $user->email_verified_at,
+                'password' => $user->password,
+                'remember_token' => $user->remember_token,
+                'created_at' => $user->created_at,
+                'updated_at' => $user->updated_at,
+            ]);
+        }
+
+        // 3. Удаляем старую таблицу и переименовываем новую
+        Schema::drop('users');
+        Schema::rename('users_new', 'users');
+    }
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        /// Возвращаем старую структуру users
+        Schema::drop('users');
+        Schema::create('users', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('email')->unique();
+            $table->timestamp('email_verified_at')->nullable();
+            $table->string('password');
+            $table->rememberToken();
+            $table->timestamps();
+        });
+    }
+};

--- a/app/phpunit.xml
+++ b/app/phpunit.xml
@@ -22,8 +22,8 @@
         <env name="APP_MAINTENANCE_DRIVER" value="file"/>
         <env name="BCRYPT_ROUNDS" value="4"/>
         <env name="CACHE_STORE" value="array"/>
-        <!-- <env name="DB_CONNECTION" value="sqlite"/> -->
-        <!-- <env name="DB_DATABASE" value=":memory:"/> -->
+        <env name="DB_CONNECTION" value="sqlite"/>
+        <env name="DB_DATABASE" value=":memory:"/>
         <env name="MAIL_MAILER" value="array"/>
         <env name="PULSE_ENABLED" value="false"/>
         <env name="QUEUE_CONNECTION" value="sync"/>

--- a/app/tests/Feature/Auth/AuthenticationTest.php
+++ b/app/tests/Feature/Auth/AuthenticationTest.php
@@ -2,7 +2,7 @@
 
 namespace Tests\Feature\Auth;
 
-use App\Models\User;
+use App\Users\Infrastructure\Database\Eloquent\Models\UserModel;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
@@ -19,7 +19,7 @@ class AuthenticationTest extends TestCase
 
     public function test_users_can_authenticate_using_the_login_screen(): void
     {
-        $user = User::factory()->create();
+        $user = UserModel::factory()->create();
 
         $response = $this->post('/login', [
             'email' => $user->email,
@@ -32,7 +32,7 @@ class AuthenticationTest extends TestCase
 
     public function test_users_can_not_authenticate_with_invalid_password(): void
     {
-        $user = User::factory()->create();
+        $user = UserModel::factory()->create();
 
         $this->post('/login', [
             'email' => $user->email,
@@ -44,7 +44,7 @@ class AuthenticationTest extends TestCase
 
     public function test_users_can_logout(): void
     {
-        $user = User::factory()->create();
+        $user = UserModel::factory()->create();
 
         $response = $this->actingAs($user)->post('/logout');
 

--- a/app/tests/Feature/Auth/EmailVerificationTest.php
+++ b/app/tests/Feature/Auth/EmailVerificationTest.php
@@ -2,7 +2,7 @@
 
 namespace Tests\Feature\Auth;
 
-use App\Models\User;
+use App\Users\Infrastructure\Database\Eloquent\Models\UserModel;
 use Illuminate\Auth\Events\Verified;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Event;
@@ -15,7 +15,7 @@ class EmailVerificationTest extends TestCase
 
     public function test_email_verification_screen_can_be_rendered(): void
     {
-        $user = User::factory()->unverified()->create();
+        $user = UserModel::factory()->unverified()->create();
 
         $response = $this->actingAs($user)->get('/verify-email');
 
@@ -24,7 +24,7 @@ class EmailVerificationTest extends TestCase
 
     public function test_email_can_be_verified(): void
     {
-        $user = User::factory()->unverified()->create();
+        $user = UserModel::factory()->unverified()->create();
 
         Event::fake();
 
@@ -43,7 +43,7 @@ class EmailVerificationTest extends TestCase
 
     public function test_email_is_not_verified_with_invalid_hash(): void
     {
-        $user = User::factory()->unverified()->create();
+        $user = UserModel::factory()->unverified()->create();
 
         $verificationUrl = URL::temporarySignedRoute(
             'verification.verify',

--- a/app/tests/Feature/Auth/PasswordConfirmationTest.php
+++ b/app/tests/Feature/Auth/PasswordConfirmationTest.php
@@ -2,7 +2,7 @@
 
 namespace Tests\Feature\Auth;
 
-use App\Models\User;
+use App\Users\Infrastructure\Database\Eloquent\Models\UserModel;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
@@ -12,7 +12,7 @@ class PasswordConfirmationTest extends TestCase
 
     public function test_confirm_password_screen_can_be_rendered(): void
     {
-        $user = User::factory()->create();
+        $user = UserModel::factory()->create();
 
         $response = $this->actingAs($user)->get('/confirm-password');
 
@@ -21,7 +21,7 @@ class PasswordConfirmationTest extends TestCase
 
     public function test_password_can_be_confirmed(): void
     {
-        $user = User::factory()->create();
+        $user = UserModel::factory()->create();
 
         $response = $this->actingAs($user)->post('/confirm-password', [
             'password' => 'password',
@@ -33,7 +33,7 @@ class PasswordConfirmationTest extends TestCase
 
     public function test_password_is_not_confirmed_with_invalid_password(): void
     {
-        $user = User::factory()->create();
+        $user = UserModel::factory()->create();
 
         $response = $this->actingAs($user)->post('/confirm-password', [
             'password' => 'wrong-password',

--- a/app/tests/Feature/Auth/PasswordResetTest.php
+++ b/app/tests/Feature/Auth/PasswordResetTest.php
@@ -2,7 +2,7 @@
 
 namespace Tests\Feature\Auth;
 
-use App\Models\User;
+use App\Users\Infrastructure\Database\Eloquent\Models\UserModel;
 use Illuminate\Auth\Notifications\ResetPassword;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Notification;
@@ -19,22 +19,28 @@ class PasswordResetTest extends TestCase
         $response->assertStatus(200);
     }
 
+    /**
+     * @throws \Exception
+     */
     public function test_reset_password_link_can_be_requested(): void
     {
         Notification::fake();
 
-        $user = User::factory()->create();
+        $user = UserModel::factory()->create();
 
         $this->post('/forgot-password', ['email' => $user->email]);
 
         Notification::assertSentTo($user, ResetPassword::class);
     }
 
+    /**
+     * @throws \Exception
+     */
     public function test_reset_password_screen_can_be_rendered(): void
     {
         Notification::fake();
 
-        $user = User::factory()->create();
+        $user = UserModel::factory()->create();
 
         $this->post('/forgot-password', ['email' => $user->email]);
 
@@ -47,11 +53,14 @@ class PasswordResetTest extends TestCase
         });
     }
 
+    /**
+     * @throws \Exception
+     */
     public function test_password_can_be_reset_with_valid_token(): void
     {
         Notification::fake();
 
-        $user = User::factory()->create();
+        $user = UserModel::factory()->create();
 
         $this->post('/forgot-password', ['email' => $user->email]);
 

--- a/app/tests/Feature/Auth/PasswordUpdateTest.php
+++ b/app/tests/Feature/Auth/PasswordUpdateTest.php
@@ -2,7 +2,7 @@
 
 namespace Tests\Feature\Auth;
 
-use App\Models\User;
+use App\Users\Infrastructure\Database\Eloquent\Models\UserModel;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Hash;
 use Tests\TestCase;
@@ -13,7 +13,7 @@ class PasswordUpdateTest extends TestCase
 
     public function test_password_can_be_updated(): void
     {
-        $user = User::factory()->create();
+        $user = UserModel::factory()->create();
 
         $response = $this
             ->actingAs($user)
@@ -33,7 +33,7 @@ class PasswordUpdateTest extends TestCase
 
     public function test_correct_password_must_be_provided_to_update_password(): void
     {
-        $user = User::factory()->create();
+        $user = UserModel::factory()->create();
 
         $response = $this
             ->actingAs($user)

--- a/app/tests/Feature/ProfileTest.php
+++ b/app/tests/Feature/ProfileTest.php
@@ -2,7 +2,7 @@
 
 namespace Tests\Feature;
 
-use App\Models\User;
+use App\Users\Infrastructure\Database\Eloquent\Models\UserModel;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
@@ -12,7 +12,7 @@ class ProfileTest extends TestCase
 
     public function test_profile_page_is_displayed(): void
     {
-        $user = User::factory()->create();
+        $user = UserModel::factory()->create();
 
         $response = $this
             ->actingAs($user)
@@ -23,7 +23,7 @@ class ProfileTest extends TestCase
 
     public function test_profile_information_can_be_updated(): void
     {
-        $user = User::factory()->create();
+        $user = UserModel::factory()->create();
 
         $response = $this
             ->actingAs($user)
@@ -43,9 +43,12 @@ class ProfileTest extends TestCase
         $this->assertNull($user->email_verified_at);
     }
 
+    /**
+     * @throws \JsonException
+     */
     public function test_email_verification_status_is_unchanged_when_the_email_address_is_unchanged(): void
     {
-        $user = User::factory()->create();
+        $user = UserModel::factory()->create();
 
         $response = $this
             ->actingAs($user)
@@ -61,9 +64,12 @@ class ProfileTest extends TestCase
         $this->assertNotNull($user->refresh()->email_verified_at);
     }
 
+    /**
+     * @throws \JsonException
+     */
     public function test_user_can_delete_their_account(): void
     {
-        $user = User::factory()->create();
+        $user = UserModel::factory()->create();
 
         $response = $this
             ->actingAs($user)
@@ -81,7 +87,7 @@ class ProfileTest extends TestCase
 
     public function test_correct_password_must_be_provided_to_delete_account(): void
     {
-        $user = User::factory()->create();
+        $user = UserModel::factory()->create();
 
         $response = $this
             ->actingAs($user)

--- a/app/tests/Feature/Runs/RunScopesTest.php
+++ b/app/tests/Feature/Runs/RunScopesTest.php
@@ -7,7 +7,7 @@ namespace Feature\Runs;
 use App\Runs\Infrastructure\Database\Eloquent\Models\RunModel;
 use Carbon\Carbon;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Foundation\Testing\TestCase;
+use Tests\TestCase;
 
 class RunScopesTest extends TestCase
 {

--- a/app/tests/Feature/Runs/RunScopesTest.php
+++ b/app/tests/Feature/Runs/RunScopesTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Feature\Runs;
+
+use App\Runs\Infrastructure\Database\Eloquent\Models\RunModel;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\TestCase;
+
+class RunScopesTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_scopes_for_user_between_recent(): void
+    {
+        RunModel::factory()->count(2)->create([
+            'user_id' => 1,
+            'run_at' => Carbon::parse('2025-09-10 10:00:00', 'UTC'),
+        ]);
+
+        RunModel::factory()->count(2)->create([
+            'user_id' => 2,
+            'run_at'  => Carbon::parse('2025-09-12 10:00:00', 'UTC'),
+        ]);
+
+        RunModel::factory()->create([
+            'user_id' => 1,
+            'run_at'  => Carbon::parse('2025-08-01 10:00:00', 'UTC'), // вне диапазона
+        ]);
+
+        $from = Carbon::parse('2025-09-01 00:00:00', 'UTC');
+        $to   = Carbon::parse('2025-09-30 23:59:59', 'UTC');
+
+        $ids = RunModel::query()
+            ->forUser(1)
+            ->between($from, $to)
+            ->recent()
+            ->pluck('user_id')
+            ->all();
+
+        $this->assertCount(2, $ids);
+        $this->assertEquals([1, 1], $ids);
+    }
+}

--- a/app/tests/Feature/UserTest.php
+++ b/app/tests/Feature/UserTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Feature;
+
+use App\Users\Domain\Contracts\UserRepository;
+use App\Users\Domain\Entity\User;
+use Illuminate\Contracts\Container\BindingResolutionException;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class UserTest extends TestCase
+{
+    use RefreshDatabase;
+    /**
+     * @throws BindingResolutionException
+     */
+    public function test_user_repository_works(): void
+    {
+        $repository = $this->app->make(UserRepository::class);
+
+        $user = new User(
+            'John Doe',
+            'test@example.com',
+            'password',
+            null
+        );
+        $savedUser = $repository->store($user);
+        $this->assertInstanceOf(User::class, $savedUser);
+        $this->assertEquals('John Doe', $savedUser->name);
+        $this->assertNotNull($savedUser->ulid); // ULID должен быть сгенерирован
+        $this->assertIsString($savedUser->ulid); // ULID должен быть строкой
+    }
+}


### PR DESCRIPTION
## 🎯 Цель
Переход на DDD архитектуру для User с поддержкой ULID вместо обычных ID.

## ✅ Что реализовано

### DDD структура:
- **User Entity** - доменная сущность с бизнес-логикой
- **UserRepository** - интерфейс для работы с данными
- **EloquentUserRepository** - реализация через Eloquent
- **UserModel** - Eloquent модель с HasUlids трейтом
- **UsersServiceProvider** - регистрация DI

### ULID поддержка:
- Автогенерация ULID при создании пользователей
- Безопасность - нельзя угадать следующий ID
- Сортировка по времени создания
- Совместимость с Laravel

### Обновления:
- Все контроллеры переведены на новый подход
- Все тесты обновлены (27 тестов, 67 assertions)
- Все Request классы исправлены
- UserFactory обновлен

## 🧪 Тестирование
- ✅ 27 тестов проходят
- ✅ Регистрация работает
- ✅ Аутентификация работает
- ✅ Сброс паролей работает
- ✅ Обновление профиля работает

## 📁 Структура

```
app/Users/
├── Domain/
│ ├── Entity/User.php
│ └── Contracts/UserRepository.php
├── Infrastructure/
│ └── Database/Eloquent/
│ ├── Models/UserModel.php
│ └── Repositories/EloquentUserRepository.php
└── UsersServiceProvider.php
```

## 🔄 Breaking Changes
- Удален `App\Models\User`
- Все ссылки на старый User обновлены