### PR TITLE
refactor(ddd): вынесение Shared/UI Controller, перенос User в модуль Users, обновление провайдеров

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,10 @@ stan-baseline: ## Сгенерировать baseline для PHPStan
 	$(DC) exec -T $(APP) php -d memory_limit=-1 vendor/bin/phpstan analyse --generate-baseline=phpstan-baseline.neon
 
 # ---------- Тесты ----------
-test: ensure-env ## Запустить тесты
+test:
+	$(DC) exec $(APP) php artisan test
+
+phpunit: ensure-env ## Запустить тесты
 	$(DC) exec -T $(APP) php artisan key:generate --no-interaction || true
 	$(DC) exec -T $(APP) php artisan migrate --graceful --no-interaction || true
 	$(DC) exec -T $(APP) vendor/bin/phpunit --colors=always
@@ -50,4 +53,4 @@ test-coverage: ensure-env
 	$(DC) exec -T $(APP) php -d xdebug.mode=coverage vendor/bin/phpunit --coverage-text --colors=always
 
 # ---------- Комбо для локальной проверки перед пушем ----------
-ci: deps lint stan test ## Локальный аналог CI-гонки
+ci: deps lint stan phpunit ## Локальный аналог CI-гонки

--- a/app/Http/Controllers/Controller.php
+++ b/app/Http/Controllers/Controller.php
@@ -2,7 +2,7 @@
 
 namespace App\Http\Controllers;
 
-abstract class Controller
+abstract class Controller extends \App\Shared\UI\Http\Controller
 {
     //
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -1,48 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Models;
 
-// use Illuminate\Contracts\Auth\MustVerifyEmail;
-use Illuminate\Database\Eloquent\Factories\HasFactory;
-use Illuminate\Foundation\Auth\User as Authenticatable;
-use Illuminate\Notifications\Notifiable;
-
-class User extends Authenticatable
-{
-    /** @use HasFactory<\Database\Factories\UserFactory> */
-    use HasFactory, Notifiable;
-
-    /**
-     * The attributes that are mass assignable.
-     *
-     * @var list<string>
-     */
-    protected $fillable = [
-        'name',
-        'email',
-        'password',
-    ];
-
-    /**
-     * The attributes that should be hidden for serialization.
-     *
-     * @var list<string>
-     */
-    protected $hidden = [
-        'password',
-        'remember_token',
-    ];
-
-    /**
-     * Get the attributes that should be cast.
-     *
-     * @return array<string, string>
-     */
-    protected function casts(): array
-    {
-        return [
-            'email_verified_at' => 'datetime',
-            'password' => 'hashed',
-        ];
-    }
-}
+class User extends \App\Users\Infrastructure\Database\Eloquent\Models\User {}

--- a/app/Shared/Infrastructure/Providers/AppServiceProvider.php
+++ b/app/Shared/Infrastructure/Providers/AppServiceProvider.php
@@ -1,6 +1,8 @@
 <?php
 
-namespace App\Providers;
+declare(strict_types=1);
+
+namespace App\Shared\Infrastructure\Providers;
 
 use Illuminate\Support\ServiceProvider;
 

--- a/app/Shared/UI/Http/Controller.php
+++ b/app/Shared/UI/Http/Controller.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shared\UI\Http;
+
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use Illuminate\Foundation\Bus\DispatchesJobs;
+use Illuminate\Foundation\Validation\ValidatesRequests;
+
+abstract class Controller
+{
+    use AuthorizesRequests, DispatchesJobs, ValidatesRequests;
+}

--- a/app/Users/Infrastructure/Database/Eloquent/Models/User.php
+++ b/app/Users/Infrastructure/Database/Eloquent/Models/User.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Users\Infrastructure\Database\Eloquent\Models;
+
+// use Illuminate\Contracts\Auth\MustVerifyEmail;
+use Database\Factories\UserFactory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Foundation\Auth\User as Authenticatable;
+use Illuminate\Notifications\Notifiable;
+
+class User extends Authenticatable
+{
+    /** @use HasFactory<UserFactory> */
+    use HasFactory;
+
+    use Notifiable;
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var list<string>
+     */
+    protected $fillable = [
+        'name',
+        'email',
+        'password',
+    ];
+
+    /**
+     * The attributes that should be hidden for serialization.
+     *
+     * @var list<string>
+     */
+    protected $hidden = [
+        'password',
+        'remember_token',
+    ];
+
+    /**
+     * Get the attributes that should be cast.
+     *
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'email_verified_at' => 'datetime',
+            'password' => 'hashed',
+        ];
+    }
+
+    protected static function newFactory(): UserFactory
+    {
+        return UserFactory::new();
+    }
+}

--- a/bootstrap/providers.php
+++ b/bootstrap/providers.php
@@ -1,5 +1,5 @@
 <?php
 
 return [
-    App\Providers\AppServiceProvider::class,
+    \App\Shared\Infrastructure\Providers\AppServiceProvider::class,
 ];

--- a/config/auth.php
+++ b/config/auth.php
@@ -62,7 +62,7 @@ return [
     'providers' => [
         'users' => [
             'driver' => 'eloquent',
-            'model' => env('AUTH_MODEL', App\Models\User::class),
+            'model' => env('AUTH_MODEL', \App\Users\Infrastructure\Database\Eloquent\Models\User::class),
         ],
 
         // 'users' => [

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -2,15 +2,18 @@
 
 namespace Database\Factories;
 
+use App\Users\Infrastructure\Database\Eloquent\Models\User;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Str;
 
 /**
- * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\User>
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Users\Infrastructure\Database\Eloquent\Models\User>
  */
 class UserFactory extends Factory
 {
+    protected $model = User::class;
+
     /**
      * The current password being used by the factory.
      */

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -2,9 +2,10 @@
 
 namespace Database\Seeders;
 
-use App\Models\User;
-// use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use App\Users\Infrastructure\Database\Eloquent\Models\User;
 use Illuminate\Database\Seeder;
+
+// use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 
 class DatabaseSeeder extends Seeder
 {


### PR DESCRIPTION
## 📝 Что сделано

- Вынесен базовый контроллер в `App\Shared\UI\Http\Controller`
- Контроллер `App\Http\Controllers\Controller` теперь наследуется от общего
- Перенесена модель `User` в модуль `App\Users\Infrastructure\Database\Eloquent\Models`
- `App\Models\User` стал прокси-классом, расширяющим новую модель
- Провайдер `AppServiceProvider` перенесён в `App\Shared\Infrastructure\Providers`
- Обновлены ссылки в `bootstrap/providers.php` и `config/auth.php`
- Фабрика `UserFactory` теперь явно привязана к новой модели
- В `Makefile`:
	- Разделены цели `test` и `phpunit`
	- Обновлена цель `ci`, теперь использует `phpunit` (с миграциями и ключом)

---

## 🔍 Как проверить

1. Собрать окружение:
	```
	make up
	```
2. Проверить, что приложение поднимается:
	```
	make shell
	php artisan about
	```
3. Убедиться, что аутентификация работает:
	```
	php artisan migrate:fresh --seed
	php artisan tinker
	>>> App\Models\User::first()
	```
4. Проверить тесты:
	```
	make test        # быстрый artisan test
	make phpunit     # полный прогон с миграциями
	make ci          # локальный аналог CI
	```

---

## ⚙️ Миграции / Очереди / Конфиги

- [ ] Миграции
- [ ] Очереди
- [x] Конфиги `.env` / `bootstrap/providers.php`
- [ ] Другое: —

---

## 🧾 Примечания

- Подготовительный шаг для миграции `User` на **ULID**
- Структура проекта выровнена под DDD: общий слой `Shared`, модуль `Users`
- Старые ссылки на `App\Models\User` остаются рабочими через прокси-класс