### PR TITLE
feat: переход на ULID для идентификаторов пользователей

### DIFF
--- a/app/Users/Domain/ValueObjects/UserId.php
+++ b/app/Users/Domain/ValueObjects/UserId.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Users\Domain\ValueObjects;
+
+use Illuminate\Support\Str;
+use InvalidArgumentException;
+
+final readonly class UserId
+{
+    private function __construct(private string $value)
+    {
+        if (! Str::isUlid($this->value)) {
+            throw new InvalidArgumentException(
+                "Invalid ULID format: {$this->value}"
+            );
+        }
+    }
+
+    public static function generate(): self
+    {
+        return new self((string) Str::ulid());
+    }
+
+    public static function fromString(string $value): self
+    {
+        return new self($value);
+    }
+
+    public function toString(): string
+    {
+        return $this->value;
+    }
+
+    public function equals(self $other): bool
+    {
+        return $this->value === $other->value;
+    }
+}

--- a/app/Users/Infrastructure/Database/Eloquent/Models/User.php
+++ b/app/Users/Infrastructure/Database/Eloquent/Models/User.php
@@ -6,6 +6,7 @@ namespace App\Users\Infrastructure\Database\Eloquent\Models;
 
 // use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Database\Factories\UserFactory;
+use Illuminate\Database\Eloquent\Concerns\HasUlids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
@@ -13,9 +14,7 @@ use Illuminate\Notifications\Notifiable;
 class User extends Authenticatable
 {
     /** @use HasFactory<UserFactory> */
-    use HasFactory;
-
-    use Notifiable;
+    use HasFactory, HasUlids, Notifiable;
 
     /**
      * The attributes that are mass assignable.

--- a/database/migrations/0001_01_01_000000_create_users_table.php
+++ b/database/migrations/0001_01_01_000000_create_users_table.php
@@ -12,7 +12,7 @@ return new class extends Migration
     public function up(): void
     {
         Schema::create('users', function (Blueprint $table) {
-            $table->id();
+            $table->ulid('id')->primary();
             $table->string('name');
             $table->string('email')->unique();
             $table->timestamp('email_verified_at')->nullable();
@@ -29,12 +29,14 @@ return new class extends Migration
 
         Schema::create('sessions', function (Blueprint $table) {
             $table->string('id')->primary();
-            $table->foreignId('user_id')->nullable()->index();
+            $table->ulid('user_id')->nullable()->index();
             $table->string('ip_address', 45)->nullable();
             $table->text('user_agent')->nullable();
             $table->longText('payload');
             $table->integer('last_activity')->index();
+            $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
         });
+
     }
 
     /**


### PR DESCRIPTION
## Описание
Переход на ULID для идентификаторов пользователей

## Изменения
- Модель User использует трейт HasUlids
- Миграции переведены на ULID
- Добавлен Value Object UserId для доменного слоя
- Внешний ключ в sessions с каскадным удалением

## Проверки
- [x] lint (Laravel Pint)
- [x] stan (PHPStan)
- [x] test (PHPUnit)

## DDD/Hexagonal
- Value Object с защитой инвариантов
- Разделение домена и инфраструктуры